### PR TITLE
update to map.apps 4.20.0-SNAPSHOT and @arcgis/core 4.33.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
         "watch-types": "tsc -w --noEmit"
     },
     "devDependencies": {
+        "@arcgis/core": "4.33.8",
         "@conterra/ct-mapapps-typings": "~4.18.3",
         "@conterra/mapapps-mocha-runner": "1.1.1",
         "@conterra/reactivity-core": "^0.4.0",
         "@types/chai": "4.3.10",
         "@types/license-checker": "^25.0.6",
         "@types/mocha": "10.0.4",
-        "arcgis-js-api": "4.29.10",
         "chai": "4.3.10",
         "ct-mapapps-browser-sync": "0.0.41",
         "ct-mapapps-gulp-js": "0.10.3",

--- a/pom.xml
+++ b/pom.xml
@@ -502,7 +502,7 @@
         <root.build.outputPath>${project.build.directory}/webapp</root.build.outputPath>
         <js.build.outputPath>${root.build.outputPath}/js</js.build.outputPath>
 
-        <mapapps.version>4.18.3</mapapps.version>
+        <mapapps.version>4.20.0-SNAPSHOT</mapapps.version>
         <!-- JS lib versions -->
         <apprt.version>${mapapps.version}</apprt.version>
 

--- a/src/main/js/bundles/dn_elevationprofile/ElevationProfileWidgetController.js
+++ b/src/main/js/bundles/dn_elevationprofile/ElevationProfileWidgetController.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import ElevationProfile from "esri/widgets/ElevationProfile";
+import ElevationProfile from "@arcgis/core/widgets/ElevationProfile";
 import EsriDijit from "esri-widgets/EsriDijit";
 import ct_util from "ct/ui/desktop/util";
 import async from "apprt-core/async";
@@ -37,7 +37,7 @@ export default class ElevationProfileWidgetController {
         this.#tool = evt.tool;
         this._getView().then((view) => {
             const widget = this.getWidget(view);
-            widget.own({
+            widget.addHandles({
                 remove() {
                     widget.destroy();
                 }

--- a/src/main/js/bundles/dn_elevationprofile/manifest.json
+++ b/src/main/js/bundles/dn_elevationprofile/manifest.json
@@ -6,7 +6,7 @@
     "vendor": "con terra GmbH",
     "productName": "devnet-mapapps-elevation-profile",
     "dependencies": {
-        "esri": "^4.18.0",
+        "@arcgis/core": "^4.33.8",
         "esri-widgets": "^4.11.0",
         "map-widget": "^4.11.0"
     },


### PR DESCRIPTION
The arcgis api moved to the new package @arcgis/core. Instead of 'own' the function 'addHandles' has to be used, see ElevationProfileWidgetController.js file.